### PR TITLE
Add `mount` method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@
 export * from "./fetch";
 export * from "./proxy";
 export * from "./pipeline";
+export * from "./mount";
 
 import * as middleware from "./middleware"
 export { middleware }

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -1,0 +1,56 @@
+import { normalizeRequest, FetchFunction } from '.'
+
+/**
+ * MountInfo can either be a string or a RegExp.
+ */
+export type MountInfo = [string | RegExp, FetchFunction]
+
+/**
+ * Allows you to mount routes to different proxied backends
+ *
+ * Example:
+ *
+ * ```javascript
+ * import { mount, MountInfo, proxy, middleware, pipeline } from '@fly/cdn'
+ *
+ * const routes: MountInfo[] = [
+ *  ['/blog', proxy('https://medium.com/blog')],
+ *  ['/docs', proxy('https://docs.example.com/docs')],
+ *  [/^\/(?:[a-z]{2}(-[A-Z]{2})?\/)?products/, proxy('https://app.example.com')] // ie, /de-DE/products
+ * ]
+ *
+ * const p = pipeline(middleware.httpsUpgrader, middleware.autoWebp)
+ * const routerApp = p(mount(routes))
+ *
+ * fly.http.respondWith(routerApp)
+ * ```
+ *
+ * @param routes array of tuples, with routes as string|RegExp and proxied backend
+ * @returns a combinedfunction that can be used anywhere that wants `fetch`
+ */
+function mount(paths: MountInfo[]) {
+  function matchMount(req: RequestInfo, init?: RequestInit) {
+    req = normalizeRequest(req)
+    const url = new URL(req.url)
+    for (const [p, f] of paths) {
+      if (typeof p === 'string' && url.pathname.startsWith(p)) {
+        return f
+      } else if (p instanceof RegExp && url.pathname.match(p)) {
+        return f
+      }
+    }
+    return null
+  }
+
+  const fn = async function mountFetch(req: RequestInfo, init?: RequestInit) {
+    const f = matchMount(req, init)
+    if (f) {
+      return f(req, init)
+    }
+    return new Response('no mount found', { status: 404 })
+  }
+
+  return Object.assign(fn, { match: matchMount })
+}
+
+export { mount }

--- a/src/mount.ts
+++ b/src/mount.ts
@@ -6,7 +6,7 @@ import { normalizeRequest, FetchFunction } from '.'
 export type MountInfo = [string | RegExp, FetchFunction]
 
 /**
- * Allows you to mount routes to different proxied backends
+ * Allows you to mount routes to different proxied backends (supports RegExp)
  *
  * Example:
  *
@@ -16,7 +16,7 @@ export type MountInfo = [string | RegExp, FetchFunction]
  * const routes: MountInfo[] = [
  *  ['/blog', proxy('https://medium.com/blog')],
  *  ['/docs', proxy('https://docs.example.com/docs')],
- *  [/^\/(?:[a-z]{2}(-[A-Z]{2})?\/)?products/, proxy('https://app.example.com')] // ie, /de-DE/products
+ *  [/^\/(?:[a-z]{2}(-[A-Z]{2})?\/)?app/, proxy('https://app.example.com')] // ie, /de-DE/products
  * ]
  *
  * const p = pipeline(middleware.httpsUpgrader, middleware.autoWebp)

--- a/src/pipeline.ts
+++ b/src/pipeline.ts
@@ -32,6 +32,7 @@ export type PipelineStage = FetchGenerator | [FetchGenerator, any[]]
  * const p = pipeline(fetch, addHeader)
  *
  * fly.http.respondWith(p)
+ * ```
  *
  * @param stages fetch generator functions that apply additional logic
  * @returns a combinedfunction that can be used anywhere that wants `fetch`

--- a/test/mount.spec.ts
+++ b/test/mount.spec.ts
@@ -1,22 +1,47 @@
 import { expect } from 'chai'
-import { mount, MountInfo, proxy } from '../src'
+import { mount, MountInfo } from '../src'
 
 const routes: MountInfo[] = [
-  ['/blog', proxy('https://medium.com/blog')],
-  ['/docs', proxy('https://docs.site.com/docs')],
-  [/^\/(?:[a-z]{2}(-[A-Z]{2})?\/)?app/, proxy('https://www.site.com/app')],
-  ['/', proxy('https://www.site.com')],
+  ['/blog', async (req, init) => await new Response('Blog site')],
+  ['/docs', async (req, init) => await new Response('Docs site')],
+  [/^\/(?:[a-z]{2}(-[A-Z]{2})?\/)?app/, async (req, init) => await new Response('App site')],
+  ['/', async (req, init) => await new Response('Main site')],
 ]
 
 const app = mount(routes)
 
+async function checkRoutingAssertions(resp: Response, respText: String) {
+  expect(resp.status).to.eq(200)
+  expect(resp.ok).to.be.true
+  expect(await resp.text()).to.eq(respText)
+}
+
 describe('mount', () => {
-  it('should route properly', async () => {
-    const resp = await app(new Request('http://localhost/blog'))
-    console.log('*************** resp', resp)
-    // expect(p.stages).to.exist
-    // expect(p.stages.length).to.eq(2)
-    // expect(p.stages[0]).to.eq(outer)
-    // expect(p.stages[1]).to.eq(inner)
+  it('should route to /blog properly', async () => {
+    const resp = await app(new Request('http://www.site.com/blog'))
+    checkRoutingAssertions(resp, 'Blog site')
+  })
+
+  it('should route to /docs properly', async () => {
+    const resp = await app(new Request('http://www.site.com/docs'))
+    checkRoutingAssertions(resp, 'Docs site')
+  })
+
+  it('should route to /app properly', async () => {
+    const resp = await app(new Request('http://www.site.com/app'))
+    checkRoutingAssertions(resp, 'App site')
+  })
+
+  it('should route to /de-DE/app properly', async () => {
+    const resp = await app(new Request('http://www.site.com/de-DE/app'))
+    checkRoutingAssertions(resp, 'App site')
+  })
+
+  it('should route to /* properly', async () => {
+    const resp = await app(new Request('http://www.site.com/'))
+    checkRoutingAssertions(resp, 'Main site')
+
+    const resp2 = await app(new Request('http://www.site.com/foo'))
+    checkRoutingAssertions(resp2, 'Main site')
   })
 })

--- a/test/mount.spec.ts
+++ b/test/mount.spec.ts
@@ -1,0 +1,22 @@
+import { expect } from 'chai'
+import { mount, MountInfo, proxy } from '../src'
+
+const routes: MountInfo[] = [
+  ['/blog', proxy('https://medium.com/blog')],
+  ['/docs', proxy('https://docs.site.com/docs')],
+  [/^\/(?:[a-z]{2}(-[A-Z]{2})?\/)?app/, proxy('https://www.site.com/app')],
+  ['/', proxy('https://www.site.com')],
+]
+
+const app = mount(routes)
+
+describe('mount', () => {
+  it('should route properly', async () => {
+    const resp = await app(new Request('http://localhost/blog'))
+    console.log('*************** resp', resp)
+    // expect(p.stages).to.exist
+    // expect(p.stages.length).to.eq(2)
+    // expect(p.stages[0]).to.eq(outer)
+    // expect(p.stages[1]).to.eq(inner)
+  })
+})


### PR DESCRIPTION
 Allows you to mount routes to different proxied backends (supports RegExp)
 
 Example:
 
 ```javascript
 import { mount, MountInfo, proxy, middleware, pipeline } from '@fly/cdn'
 
 const routes: MountInfo[] = [
  ['/blog', proxy('https://medium.com/blog')],
  ['/docs', proxy('https://docs.example.com/docs')],
  [/^\/(?:[a-z]{2}(-[A-Z]{2})?\/)?app/, proxy('https://app.example.com')] // ie, /de-DE/products
 ]
 
 const p = pipeline(middleware.httpsUpgrader, middleware.autoWebp)
 const routerApp = p(mount(routes))
 
 fly.http.respondWith(routerApp)
 ```